### PR TITLE
Исправление this для корректной работы chai

### DIFF
--- a/test.blocks/chai/chai.js
+++ b/test.blocks/chai/chai.js
@@ -1,4 +1,6 @@
 modules.define('chai', function(provide) {
+  
+(function() {
 
 /**
  * Require the given path.
@@ -4251,4 +4253,7 @@ if (typeof exports == "object") {
 }
 
 provide(require("chai"));
+
+})(this.global);
+
 });


### PR DESCRIPTION
chai везде внутри использует this, надеясь, что он указывает на глобальный контекст. В ym, начиная с 0.0.6, контекст исполнения модуля отличается от глобального, поэтому нужно явно пробросить его.
