### PR TITLE
Use only v2 techs

### DIFF
--- a/bem/levels/examples.js
+++ b/bem/levels/examples.js
@@ -1,8 +1,8 @@
 exports.getTechs = function() {
     
     return {
-        'title.txt'  : '',
-        'bemjson.js' : ''
+        'title.txt'  : 'bem/lib/tech/v2',
+        'bemjson.js' : 'bem/lib/tech/v2'
     };
     
 };

--- a/bem/levels/tests.js
+++ b/bem/levels/tests.js
@@ -3,8 +3,8 @@ var BEM = require('bem');
 exports.getTechs = function() {
 
     return {
-        'title.txt'  : '',
-        'bemjson.js' : ''
+        'title.txt'  : 'bem/lib/tech/v2',
+        'bemjson.js' : 'bem/lib/tech/v2'
     };
 
 };

--- a/bem/techs/test-tmpl.js
+++ b/bem/techs/test-tmpl.js
@@ -1,6 +1,7 @@
 var PATH = require('path'),
     tmpl = require('bem/lib/template');
 
+exports.API_VER = 2;
 exports.techMixin = {
 
     getCreateResult : function(path, suffix, vars) {

--- a/test.blocks/.bem/level.js
+++ b/test.blocks/.bem/level.js
@@ -1,7 +1,7 @@
 exports.getTechs = function() {
     return {
-        'js'            : 'js',
-        'css'           : 'css',
-        'bemhtml'       : ''
+        'js'            : 'v2/js',
+        'css'           : 'v2/css',
+        'bemhtml'       : 'bem/lib/tech/v2'
     };
 };


### PR DESCRIPTION
Configure library to use v2 techs only, including base techs from
bem-tools.
