### PR TITLE
Fix race when running tests from bem-server

### DIFF
--- a/bem/nodes/tests.js
+++ b/bem/nodes/tests.js
@@ -130,8 +130,7 @@ registry.decl(TestNodeName, examplesNodes.ExampleNodeName, {
                 tech,
                 this.level.resolveTech(tech),
                 bundleNode,
-                magicNode,
-                true);
+                magicNode);
     },
 
     getAutogenTechName : function() {

--- a/bem/techs/test-tmpl.js
+++ b/bem/techs/test-tmpl.js
@@ -1,4 +1,5 @@
 var PATH = require('path'),
+    bemUtil = require('bem/lib/util'),
     tmpl = require('bem/lib/template');
 
 exports.API_VER = 2;
@@ -32,6 +33,13 @@ exports.techMixin = {
             TmplDecl : envProps.TmplDecl || "",
             TmplContent : envProps.TmplContent || ""
         });
+    },
+
+    storeCreateResult: function(path, suffix, res, force) {
+        bemUtil.mkdirs(PATH.dirname(path));
+        return force?
+            bemUtil.writeFile(path, res) :
+            bemUtil.writeFileIfDiffers(path, res);
     },
 
     getCreateSuffixes : function() {


### PR DESCRIPTION
Suppose that tests are running from bem server and user requests `desktop.sets/some.tests/default/default.html`. What happens:
1. Browser requests `desktop.sets/some.tests/default/default.html`;
2. Build is performed for this file and results are sent back to browser;
3. After loading html page, browser requests both `js` and `css` simultaneously;
4. Execution of build plan for `js` starts. As a part of a process, `bemjson.js` is created with `test-tmpl` tech;
5. Execution of build plan for `css` starts on different worker. `bemjson.js` is generated too for this step. In order to write it, `bem-tools` opens file with `w` flag, write content of the file and closes it.
6. Occasionally, building of `bemdecl.js` for `js` starts after `bemjson` file is opened in write mode by `css` plan (overriding its content), but before new content is written. Thus, no blocks from bemjson appear in bemdecl.

More general solution for i/o sync will be implemented in future versions of `bem-tools`, for now its just fix for bem-pr.
